### PR TITLE
use "md5" instead of "md5 -r"

### DIFF
--- a/lenv
+++ b/lenv
@@ -165,9 +165,9 @@ sub download
 
     # verify checksum
     if( $checksum ){
-        $sum = `$OPENSSL md5 -r $src`;
+        $sum = `$OPENSSL md5 $src`;
         chomp( $sum );
-        die "checksum of $file does not match $checksum" if $sum !~ /^$checksum/;
+        die "checksum of $file does not match $checksum" if $sum !~ /$checksum/;
     }
 
     return $src;


### PR DESCRIPTION
- mac os x does not have the -r option for "openssl md5"
- remove the initial non-digest part of the sum
