### PR TITLE
Update LuaRocks release URL

### DIFF
--- a/lenv
+++ b/lenv
@@ -250,13 +250,13 @@ _EOS_
         if( $_ =~ /LUA_C?PATH='(.+)'/ )
         {
             my @arr = split( /;/, $1 );
-            
+
             foreach( @arr )
             {
                 if( $_ =~ $regex ){
                     my $dir = "${instpath}/$1/$2";
                     my $dst = "${instpath}/luarocks/$1";
-                    
+
                     print "ln -s $dir, $dst\n";
                     if( -e $dst ){
                         unlink $dst or die $!;
@@ -488,7 +488,7 @@ sub parseRocksVers
         # version 2.2 or later
         if( $3 >= 2.2 ){
             print "$2\t$1\n";
-            push @arr, "$2 http://keplerproject.github.io/luarocks/releases/$1 $1";
+            push @arr, "$2 http://luarocks.github.io/luarocks/releases/$1 $1";
         }
     }
     @arr = reverse( sort @arr );
@@ -524,7 +524,7 @@ sub parseLuaVers
     my ( $file, $fh ) = @_;
     my $html = <$fh>;
     my @arr = ();
-    
+
     # print and save versions
     while( $html =~ /href="(lua-((\d+\.\d+)(?:\.\d+)*)\.tar\.gz)".+?md5:\s*([a-f0-9]+)/sig )
     {
@@ -585,7 +585,7 @@ sub cmdFetch
         {
             name    => 'luarocks',
             file    => $ROCKS_VERS_TXT,
-            url     => 'http://keplerproject.github.io/luarocks/releases/',
+            url     => 'http://luarocks.github.io/luarocks/releases/',
             parse   => \&parseRocksVers
         }
     );
@@ -653,7 +653,7 @@ Usage:
     lenv ls                             List installed versions
     lenv install <version> <opt...>     Download and install a <version> of lua
                                         with luarocks
-    lenv install-lj <version> <opt...>  Download and install a <version> of 
+    lenv install-lj <version> <opt...>  Download and install a <version> of
                                         luajit with luarocks
     lenv uninstall <version>            Uninstall a <version> of lua
     lenv uninstall-lj <version>         Uninstall a <version> of luajit


### PR DESCRIPTION
The release URL changed a while back and so lenv only builds old releases of LuaRocks. This updates the release URL so that it will get the latest and greatest.