### PR TITLE
Ensure path includes current directory

### DIFF
--- a/path.go
+++ b/path.go
@@ -36,7 +36,7 @@ func cmdPath() {
 				dir := prefix + strconv.Itoa(i)
 				paths = append(paths, dir+"/?.lua", dir+"/?/init.lua")
 			}
-			value = strings.Join(paths, ";")
+			value = strings.Join(paths, ";") + ";"
 
 		case "LUA_CPATH":
 			format = `export %s="%s;"`
@@ -46,7 +46,7 @@ func cmdPath() {
 				dir := prefix + strconv.Itoa(i)
 				paths = append(paths, dir+"/?.so")
 			}
-			value = strings.Join(paths, ";")
+			value = strings.Join(paths, ";") + ";"
 		}
 		printf(format, name, value)
 	}


### PR DESCRIPTION
The Perl version of `lenv path` included `;;` at the end of that path. This ensures that `.` is on the path. The Golang version does not and so Lua cannot perform relative `require`s.

This change adds `;;` for the Golang version.