### PR TITLE
Fix Lua fetch

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -16,7 +16,7 @@ var (
 	ReSemVer      = regexp.MustCompile(`(?s)^\d+(?:\.\d+){1,2}`)
 	ReLuaRocksVer = regexp.MustCompile(`(?si)href="(luarocks-([^"]+?)\.tar\.gz).*?href="(luarocks-[^"]+?\.tar\.gz\.asc)"`)
 	ReLuaJitVer   = regexp.MustCompile(`(?i)([0-9a-f]+?)\s+(LuaJIT-([^\s]+?)\.tar\.gz)`)
-	ReLuaVer      = regexp.MustCompile(`(?si)<tr>\s*<td class="name"><a href="(lua-([^"]+?)\.tar\.gz).+?class="sum">.+?sha1:\s*([0-9a-f]+).*?</td>\s*</tr>`)
+	ReLuaVer      = regexp.MustCompile(`(?si)<tr>\s*<td class="name"><a href="(lua-([^"]+?)\.tar\.gz).+?class="sum">([0-9a-f]+)</td>\s*</tr>`)
 )
 
 func isSemVer(ver string) bool {
@@ -69,7 +69,7 @@ func parseLuaVers(body []byte) List {
 	for _, m := range ReLuaVer.FindAllSubmatch(body, -1) {
 		name := string(m[1])
 		ver := string(m[2])
-		sum := "sha1:" + string(m[3])
+		sum := "sha256:" + string(m[3])
 		if isSemVer(ver) {
 			list[ver] = &ListItem{
 				Name: name,

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -34,7 +34,7 @@ func Test_parseLuaJitVers(t *testing.T) {
 }
 
 func Test_parseLuaVers(t *testing.T) {
-	exp := []string{"lua-5.4.2.tar.gz", "lua-5.4.1.tar.gz", "lua-5.4.0.tar.gz", "lua-5.3.6.tar.gz", "lua-5.3.5.tar.gz", "lua-5.3.4.tar.gz", "lua-5.3.3.tar.gz", "lua-5.3.2.tar.gz", "lua-5.3.1.tar.gz", "lua-5.3.0.tar.gz", "lua-5.2.4.tar.gz", "lua-5.2.3.tar.gz", "lua-5.2.2.tar.gz", "lua-5.2.1.tar.gz", "lua-5.2.0.tar.gz", "lua-5.1.5.tar.gz", "lua-5.1.4.tar.gz", "lua-5.1.3.tar.gz", "lua-5.1.2.tar.gz", "lua-5.1.1.tar.gz", "lua-5.1.tar.gz", "lua-5.0.3.tar.gz", "lua-5.0.2.tar.gz", "lua-5.0.1.tar.gz", "lua-5.0.tar.gz", "lua-4.0.1.tar.gz", "lua-4.0.tar.gz", "lua-3.2.2.tar.gz", "lua-3.2.1.tar.gz", "lua-3.2.tar.gz", "lua-3.1.tar.gz", "lua-3.0.tar.gz", "lua-2.5.tar.gz", "lua-2.4.tar.gz", "lua-2.2.tar.gz", "lua-2.1.tar.gz", "lua-1.1.tar.gz", "lua-1.0.tar.gz"}
+	exp := []string{"lua-5.4.4.tar.gz", "lua-5.4.3.tar.gz", "lua-5.4.2.tar.gz", "lua-5.4.1.tar.gz", "lua-5.4.0.tar.gz", "lua-5.3.6.tar.gz", "lua-5.3.5.tar.gz", "lua-5.3.4.tar.gz", "lua-5.3.3.tar.gz", "lua-5.3.2.tar.gz", "lua-5.3.1.tar.gz", "lua-5.3.0.tar.gz", "lua-5.2.4.tar.gz", "lua-5.2.3.tar.gz", "lua-5.2.2.tar.gz", "lua-5.2.1.tar.gz", "lua-5.2.0.tar.gz", "lua-5.1.5.tar.gz", "lua-5.1.4.tar.gz", "lua-5.1.3.tar.gz", "lua-5.1.2.tar.gz", "lua-5.1.1.tar.gz", "lua-5.1.tar.gz", "lua-5.0.3.tar.gz", "lua-5.0.2.tar.gz", "lua-5.0.1.tar.gz", "lua-5.0.tar.gz", "lua-4.0.1.tar.gz", "lua-4.0.tar.gz", "lua-3.2.2.tar.gz", "lua-3.2.1.tar.gz", "lua-3.2.tar.gz", "lua-3.1.tar.gz", "lua-3.0.tar.gz", "lua-2.5.tar.gz", "lua-2.4.tar.gz", "lua-2.2.tar.gz", "lua-2.1.tar.gz", "lua-1.1.tar.gz", "lua-1.0.tar.gz"}
 	names := []string{}
 
 	for ver, item := range parseLuaVers([]byte(LuaHTML)) {
@@ -102,281 +102,295 @@ Check their checksums to confirm the integrity of the packages.
 <TR>
 <TH>filename</TH>
 <TH>date</TH>
-<TH CLASS="size">size</TH>
-<TH>checksums</TH>
+<TH>size</TH>
+<TH>checksum (sha256)</TH>
+</TR>
+
+<TR>
+<TD CLASS="name"><A HREF="lua-5.4.4.tar.gz">lua-5.4.4.tar.gz</A></TD>
+<TD CLASS="date">2022-01-13</TD>
+<TD CLASS="size">360876</TD>
+<TD CLASS="sum">164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61</TD>
+</TR>
+
+<TR>
+<TD CLASS="name"><A HREF="lua-5.4.3.tar.gz">lua-5.4.3.tar.gz</A></TD>
+<TD CLASS="date">2021-03-15</TD>
+<TD CLASS="size">358216</TD>
+<TD CLASS="sum">f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.4.2.tar.gz">lua-5.4.2.tar.gz</A></TD>
 <TD CLASS="date">2020-11-13</TD>
 <TD CLASS="size">353472</TD>
-<TD CLASS="sum">md5: 49c92d6a49faba342c35c52e1ac3f81e<BR>sha1: 96d4a21393c94bed286b8dc0568f4bdde8730b22</TD>
+<TD CLASS="sum">11570d97e9d7303c0a59567ed1ac7c648340cd0db10d5fd594c09223ef2f524f</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.4.1.tar.gz">lua-5.4.1.tar.gz</A></TD>
 <TD CLASS="date">2020-09-30</TD>
 <TD CLASS="size">353965</TD>
-<TD CLASS="sum">md5: 1d575faef1c907292edd79e7a2784d30<BR>sha1: 88961e7d4fda58ca2c6163938fd48db8880e803d</TD>
+<TD CLASS="sum">4ba786c3705eb9db6567af29c91a01b81f1c0ac3124fdbf6cd94bdd9e53cca7d</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.4.0.tar.gz">lua-5.4.0.tar.gz</A></TD>
 <TD CLASS="date">2020-06-18</TD>
 <TD CLASS="size">349308</TD>
-<TD CLASS="sum">md5: dbf155764e5d433fc55ae80ea7060b60<BR>sha1: 8cdbffa8a214a23d190d7c45f38c19518ae62e89</TD>
+<TD CLASS="sum">eac0836eb7219e421a96b7ee3692b93f0629e4cdb0c788432e3d10ce9ed47e28</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.6.tar.gz">lua-5.3.6.tar.gz</A></TD>
 <TD CLASS="date">2020-09-14</TD>
 <TD CLASS="size">303770</TD>
-<TD CLASS="sum">md5: 83f23dbd5230140a3770d5f54076948d<BR>sha1: f27d20d6c81292149bc4308525a9d6733c224fa5</TD>
+<TD CLASS="sum">fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.5.tar.gz">lua-5.3.5.tar.gz</A></TD>
 <TD CLASS="date">2018-06-26</TD>
 <TD CLASS="size">303543</TD>
-<TD CLASS="sum">md5: 4f4b4f323fd3514a68e0ab3da8ce3455<BR>sha1: 112eb10ff04d1b4c9898e121d6bdf54a81482447</TD>
+<TD CLASS="sum">0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.4.tar.gz">lua-5.3.4.tar.gz</A></TD>
 <TD CLASS="date">2017-01-12</TD>
 <TD CLASS="size">303586</TD>
-<TD CLASS="sum">md5: 53a9c68bcc0eda58bdc2095ad5cdfc63<BR>sha1: 79790cfd40e09ba796b01a571d4d63b52b1cd950</TD>
+<TD CLASS="sum">f681aa518233bc407e23acf0f5887c884f17436f000d453b2491a9f11a52400c</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.3.tar.gz">lua-5.3.3.tar.gz</A></TD>
 <TD CLASS="date">2016-05-30</TD>
 <TD CLASS="size">294290</TD>
-<TD CLASS="sum">md5: 703f75caa4fdf4a911c1a72e67a27498<BR>sha1: a0341bc3d1415b814cc738b2ec01ae56045d64ef</TD>
+<TD CLASS="sum">5113c06884f7de453ce57702abaac1d618307f33f6789fa870e87a59d772aca2</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.2.tar.gz">lua-5.3.2.tar.gz</A></TD>
 <TD CLASS="date">2015-11-25</TD>
 <TD CLASS="size">288235</TD>
-<TD CLASS="sum">md5: 33278c2ab5ee3c1a875be8d55c1ca2a1<BR>sha1: 7a47adef554fdca7d0c5536148de34579134a973</TD>
+<TD CLASS="sum">c740c7bb23a936944e1cc63b7c3c5351a8976d7867c5252c8854f7b2af9da68f</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.1.tar.gz">lua-5.3.1.tar.gz</A></TD>
 <TD CLASS="date">2015-06-10</TD>
 <TD CLASS="size">282401</TD>
-<TD CLASS="sum">md5: 797adacada8d85761c079390ff1d9961<BR>sha1: 1676c6a041d90b6982db8cef1e5fb26000ab6dee</TD>
+<TD CLASS="sum">072767aad6cc2e62044a66e8562f51770d941e972dc1e4068ba719cd8bffac17</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.3.0.tar.gz">lua-5.3.0.tar.gz</A></TD>
 <TD CLASS="date">2015-01-06</TD>
 <TD CLASS="size">278045</TD>
-<TD CLASS="sum">md5: a1b0a7e92d0c85bbff7a8d27bf29f8af<BR>sha1: 1c46d1c78c44039939e820126b86a6ae12dadfba</TD>
+<TD CLASS="sum">ae4a5eb2d660515eb191bfe3e061f2b8ffe94dce73d32cfd0de090ddcc0ddb01</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.2.4.tar.gz">lua-5.2.4.tar.gz</A></TD>
 <TD CLASS="date">2015-02-26</TD>
 <TD CLASS="size">252651</TD>
-<TD CLASS="sum">md5: 913fdb32207046b273fdb17aad70be13<BR>sha1: ef15259421197e3d85b7d6e4871b8c26fd82c1cf</TD>
+<TD CLASS="sum">b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.2.3.tar.gz">lua-5.2.3.tar.gz</A></TD>
 <TD CLASS="date">2013-11-11</TD>
 <TD CLASS="size">251195</TD>
-<TD CLASS="sum">md5: dc7f94ec6ff15c985d2d6ad0f1b35654<BR>sha1: 926b7907bc8d274e063d42804666b40a3f3c124c</TD>
+<TD CLASS="sum">13c2fb97961381f7d06d5b5cea55b743c163800896fd5c5e2356201d3619002d</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.2.2.tar.gz">lua-5.2.2.tar.gz</A></TD>
 <TD CLASS="date">2013-03-21</TD>
 <TD CLASS="size">251713</TD>
-<TD CLASS="sum">md5: efbb645e897eae37cad4344ce8b0a614<BR>sha1: 0857e41e5579726a4cb96732e80d7aa47165eaf5</TD>
+<TD CLASS="sum">3fd67de3f5ed133bf312906082fa524545c6b9e1b952e8215ffbd27113f49f00</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.2.1.tar.gz">lua-5.2.1.tar.gz</A></TD>
 <TD CLASS="date">2012-06-08</TD>
 <TD CLASS="size">249882</TD>
-<TD CLASS="sum">md5: ae08f641b45d737d12d30291a5e5f6e3<BR>sha1: 6bb1b0a39b6a5484b71a83323c690154f86b2021</TD>
+<TD CLASS="sum">64304da87976133196f9e4c15250b70f444467b6ed80d7cfd7b3b982b5177be5</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.2.0.tar.gz">lua-5.2.0.tar.gz</A></TD>
 <TD CLASS="date">2011-12-12</TD>
 <TD CLASS="size">246377</TD>
-<TD CLASS="sum">md5: f1ea831f397214bae8a265995ab1a93e<BR>sha1: 08f84c355cdd646f617f09cebea48bd832415829</TD>
+<TD CLASS="sum">cabe379465aa8e388988073d59b69e76ba0025429d2c1da80821a252cdf6be0d</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.5.tar.gz">lua-5.1.5.tar.gz</A></TD>
 <TD CLASS="date">2012-02-13</TD>
 <TD CLASS="size">221213</TD>
-<TD CLASS="sum">md5: 2e115fe26e435e33b0d5c022e4490567<BR>sha1: b3882111ad02ecc6b972f8c1241647905cb2e3fc</TD>
+<TD CLASS="sum">2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.4.tar.gz">lua-5.1.4.tar.gz</A></TD>
 <TD CLASS="date">2008-08-18</TD>
 <TD CLASS="size">216679</TD>
-<TD CLASS="sum">md5: d0870f2de55d59c1c8419f36e8fac150<BR>sha1: 2b11c8e60306efb7f0734b747588f57995493db7</TD>
+<TD CLASS="sum">b038e225eaf2a5b57c9bcc35cd13aa8c6c8288ef493d52970c9545074098af3a</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.3.tar.gz">lua-5.1.3.tar.gz</A></TD>
 <TD CLASS="date">2008-01-21</TD>
 <TD CLASS="size">215817</TD>
-<TD CLASS="sum">md5: a70a8dfaa150e047866dc01a46272599<BR>sha1: 89bc9f5a351402565b8077e8123327e7cd15f004</TD>
+<TD CLASS="sum">6b5df2edaa5e02bf1a2d85e1442b2e329493b30b0c0780f77199d24f087d296d</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.2.tar.gz">lua-5.1.2.tar.gz</A></TD>
 <TD CLASS="date">2007-03-29</TD>
 <TD CLASS="size">214134</TD>
-<TD CLASS="sum">md5: 687ce4c2a1ddff18f1008490fdc4e5e0<BR>sha1: 8a460d2d7e70e93cb72bf3d584405464763cb5f0</TD>
+<TD CLASS="sum">5cf098c6fe68d3d2d9221904f1017ff0286e4a9cc166a1452a456df9b88b3d9e</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.1.tar.gz">lua-5.1.1.tar.gz</A></TD>
 <TD CLASS="date">2006-06-07</TD>
 <TD CLASS="size">207810</TD>
-<TD CLASS="sum">md5: 22f4f912f20802c11006fe9b84d5c461<BR>sha1: be13878ceef8e1ee7a4201261f0adf09f89f1005</TD>
+<TD CLASS="sum">c5daeed0a75d8e4dd2328b7c7a69888247868154acbda69110e97d4a6e17d1f0</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.1.tar.gz">lua-5.1.tar.gz</A></TD>
 <TD CLASS="date">2006-02-20</TD>
 <TD CLASS="size">206877</TD>
-<TD CLASS="sum">md5: 3e8dfe8be00a744cec2f9e766b2f2aee<BR>sha1: 1ae9ec317511d525c7999c842ca0b1ddde84e374</TD>
+<TD CLASS="sum">7f5bb9061eb3b9ba1e406a5aa68001a66cb82bac95748839dc02dd10048472c1</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.0.3.tar.gz">lua-5.0.3.tar.gz</A></TD>
 <TD CLASS="date">2006-06-19</TD>
 <TD CLASS="size">191384</TD>
-<TD CLASS="sum">md5: feee27132056de2949ce499b0ef4c480<BR>sha1: e7e91f78b8a8deb09b13436829bed557a46af8ae</TD>
+<TD CLASS="sum">1193a61b0e08acaa6eee0eecf29709179ee49c71baebc59b682a25c3b5a45671</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.0.2.tar.gz">lua-5.0.2.tar.gz</A></TD>
 <TD CLASS="date">2004-03-17</TD>
 <TD CLASS="size">190442</TD>
-<TD CLASS="sum">md5: dea74646b7e5c621fef7174df83c34b1<BR>sha1: a200cfd20a9a4c7da1206ae45dddf26186a9e0e7</TD>
+<TD CLASS="sum">a6c85d85f912e1c321723084389d63dee7660b81b8292452b190ea7190dd73bc</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.0.1.tar.gz">lua-5.0.1.tar.gz</A></TD>
 <TD CLASS="date">2003-11-25</TD>
 <TD CLASS="size">193978</TD>
-<TD CLASS="sum">md5: e0a450d84971a3f4563b98172d1e382c<BR>sha1: 03b47b4785178aca583333f01d8726a8ab9f7ae7</TD>
+<TD CLASS="sum">7a09d0e70dcaff7feae97cf9c154da05b1e5b92eaea2df7150b54bcaf8f3b9c6</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-5.0.tar.gz">lua-5.0.tar.gz</A></TD>
 <TD CLASS="date">2003-04-11</TD>
 <TD CLASS="size">187287</TD>
-<TD CLASS="sum">md5: 6f14803fad389fb1cb15d17edfeddd91<BR>sha1: 88b1bc057857c0db5ace491c4af2c917a2b803bf</TD>
+<TD CLASS="sum">4a23b3bcb812538c653033cd39fe9c9bd8030286b945c56eff280d452e4e244e</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-4.0.1.tar.gz">lua-4.0.1.tar.gz</A></TD>
 <TD CLASS="date">2002-07-04</TD>
 <TD CLASS="size">158426</TD>
-<TD CLASS="sum">md5: a31d963dbdf727f9b34eee1e0d29132c<BR>sha1: 12f1864a7ecd4b8011862a07fa3f177b2e80e7d3</TD>
+<TD CLASS="sum">df746e149cf6939e90009d2e540eee918d585b4d1bc6d68b19316a050d484d2a</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-4.0.tar.gz">lua-4.0.tar.gz</A></TD>
 <TD CLASS="date">2000-11-06</TD>
 <TD CLASS="size">157102</TD>
-<TD CLASS="sum">md5: be11522d46d33a931868c03694aaeeef<BR>sha1: 8d432c73ef6e98b81d252114be1a83182cc9607a</TD>
+<TD CLASS="sum">b476abc737bf82781cb215e59a259bf23adbdc82425907b51f37ba29c0e71337</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-3.2.2.tar.gz">lua-3.2.2.tar.gz</A></TD>
 <TD CLASS="date">2000-02-22</TD>
 <TD CLASS="size">127768</TD>
-<TD CLASS="sum">md5: 374ba5c4839709922de40b8d10382705<BR>sha1: fa50ff14c00d8523c8a3d1d3f4887ecc4400d0c3</TD>
+<TD CLASS="sum">4e04059f43acdcde5f7fd491c731df9279dac87d288a08c6eaeb31760c9876e0</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-3.2.1.tar.gz">lua-3.2.1.tar.gz</A></TD>
 <TD CLASS="date">1999-11-25</TD>
 <TD CLASS="size">127644</TD>
-<TD CLASS="sum">md5: 47264a1978df49fc1dea6ffcddb05b21<BR>sha1: d43af5a1c7a65c0ddb4b0ac06c29ecf4cdd22367</TD>
+<TD CLASS="sum">00d156f5b0c99bf46ed2fc2471b2a4bc5762aee83a809ab87bd7ec9ccc6220ea</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-3.2.tar.gz">lua-3.2.tar.gz</A></TD>
 <TD CLASS="date">1999-07-08</TD>
 <TD CLASS="size">128597</TD>
-<TD CLASS="sum">md5: a6552da3d40ae9b04489a788262279e8<BR>sha1: 84cf9f0e7d00eed3ea8b4ac2b84254b714510b34</TD>
+<TD CLASS="sum">bf8beabd41e65cbf8cb41c688eca0588fff81e1e5f67cb42bd370e1ecc585c33</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-3.1.tar.gz">lua-3.1.tar.gz</A></TD>
 <TD CLASS="date">1998-07-12</TD>
 <TD CLASS="size">114186</TD>
-<TD CLASS="sum">md5: d677f3827167eefdefc7b211397cfdfb<BR>sha1: 509485e3baafd946f4ffe2a984f8a63746adc32a</TD>
+<TD CLASS="sum">797ceabe28df53ce6dd6bfb4397d6e0b2e349b3bd0a1883c9c8ae0212d8cd7ed</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-3.0.tar.gz">lua-3.0.tar.gz</A></TD>
 <TD CLASS="date">1997-07-01</TD>
 <TD CLASS="size">99921</TD>
-<TD CLASS="sum">md5: 997558ae76c2f1cd1e10fd3835c45c6a<BR>sha1: 5c8c910353f717ba29b4fe7d538994454229b335</TD>
+<TD CLASS="sum">a3ae0fb0ffc6b365d187fea0d121772fc2a8810853b14b7e48ed31eae8494215</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-2.5.tar.gz">lua-2.5.tar.gz</A></TD>
 <TD CLASS="date">1996-11-21</TD>
 <TD CLASS="size">185786</TD>
-<TD CLASS="sum">md5: da915d58904e75b9b0fc18147e19b0bb<BR>sha1: 7920e12c40242932c22fa261ff114cc485a39d99</TD>
+<TD CLASS="sum">8ba8cc089b6ee7b5ed7fe9e0764756838943a1e52dde8bbfa70b758556056cd5</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-2.4.tar.gz">lua-2.4.tar.gz</A></TD>
 <TD CLASS="date">1996-05-17</TD>
 <TD CLASS="size">132500</TD>
-<TD CLASS="sum">md5: 5d035cc244285c1dbbcaaa0908b58965<BR>sha1: 74036935b36e6ae4ed17bd7a9408154f9a4a6b17</TD>
+<TD CLASS="sum">38ee28cd5ec5c0b75f31d65c12f587f192174c8b7fcca3decd08cdb35af282e3</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-2.2.tar.gz">lua-2.2.tar.gz</A></TD>
 <TD CLASS="date">1995-11-28</TD>
 <TD CLASS="size">108261</TD>
-<TD CLASS="sum">md5: a298b58e197ff8168ec907d6145252ef<BR>sha1: 2d8b1df94b2fb76f0f16ca1ddc54d5186b10df4b</TD>
+<TD CLASS="sum">a13cc27035b8d16bd9d29f5a1eb4403476deecd149c1d3979ad9d2ad015994f3</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-2.1.tar.gz">lua-2.1.tar.gz</A></TD>
 <TD CLASS="date">1995-09-13</TD>
 <TD CLASS="size">125334</TD>
-<TD CLASS="sum">md5: 053a9f6728cc56f6a23716a6a1ede595<BR>sha1: b9a797547f480bcb58b5d3da846c8ac8d2201df0</TD>
+<TD CLASS="sum">d65ee99f8e63d12fa952425671854add39c1233e4a9c6669ec552b16279df664</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-1.1.tar.gz">lua-1.1.tar.gz</A></TD>
 <TD CLASS="date">1995-02-02</TD>
 <TD CLASS="size">158285</TD>
-<TD CLASS="sum">md5: 9f83141cc8ea362497e272071eda5cf6<BR>sha1: 67209701eec5cc633e829d023fbff62d5d6c8e5e</TD>
+<TD CLASS="sum">e44506793fee609202d7f42e529afbc3c9a541e0fc715b3834d758f0ae41c38f</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-1.0.tar.gz">lua-1.0.tar.gz</A></TD>
 <TD CLASS="date">2003-10-10</TD>
 <TD CLASS="size">33149</TD>
-<TD CLASS="sum">md5: 96e8399fc508d128badd8ac3aa8f2119<BR>sha1: 6a82d2ae7ce9ad98c7b4824a325b91522c0d6ebb</TD>
+<TD CLASS="sum">d8ee432490a4679a4edb0abbef2d3b7b0f1fc29a39398988c4bb5eeb8d2180a6</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="lua-all.tar.gz">lua-all.tar.gz</A></TD>
-<TD CLASS="date">2020-12-08</TD>
-<TD CLASS="size">4669322</TD>
-<TD CLASS="sum">md5: 9127a2bb930d86e81e8420351375603d<BR>sha1: 1fc9740430e7d1deb91fc573a1245a73d17a872f</TD>
+<TD CLASS="date">2022-01-26</TD>
+<TD CLASS="size">5142787</TD>
+<TD CLASS="sum">a1c1d96a1e1968ad598b708e57aab720f60247d333c4d9a46f99a2d2bd32209d</TD>
 </TR>
 
 </TABLE>
@@ -386,131 +400,130 @@ Check their checksums to confirm the integrity of the packages.
 <TR>
 <TH>filename</TH>
 <TH>date</TH>
-<TH CLASS="size">size</TH>
-<TH>checksums</TH>
+<TH>size</TH>
+<TH>checksum (sha256)</TH>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-5.4.tar.gz">refman-5.4.tar.gz</A></TD>
-<TD CLASS="date">2020-10-10</TD>
-<TD CLASS="size">440320</TD>
-<TD CLASS="sum">md5: 0b33ff65c7a3516c58de5e5a5e8d02dc<BR>sha1: 6f56b4c4fae629780ae085729b46c16c67741649</TD>
+<TD CLASS="date">2021-06-17</TD>
+<TD CLASS="size">124407</TD>
+<TD CLASS="sum">5321b0045d54cbd711a6a0da3bb12f9380e8d4081b91d726171551f27d1245eb</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-5.3.tar.gz">refman-5.3.tar.gz</A></TD>
 <TD CLASS="date">2020-09-25</TD>
 <TD CLASS="size">110173</TD>
-<TD CLASS="sum">md5: 90646a8f28071a0f19d592ef15f6513f<BR>sha1: c3f6e87593d3b81959bb46e32e09ac2681a0331b</TD>
+<TD CLASS="sum">74fc89f552d6cbbcbd63edb2bf309f808e9c69fe1350eaaf254c4fecb13a0708</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-5.2.tar.gz">refman-5.2.tar.gz</A></TD>
 <TD CLASS="date">2016-07-01</TD>
 <TD CLASS="size">102134</TD>
-<TD CLASS="sum">md5: 41c445ccafae43b0fa5a7c6b03453bc9<BR>sha1: c1419e4d184322d66febac7ca041d8b15fc6cefe</TD>
+<TD CLASS="sum">562da8f399ea55eb2c85bdfd2d93d90b7cc7ea7b041c41718d70ec9ed8d085c4</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-5.1.tar.gz">refman-5.1.tar.gz</A></TD>
 <TD CLASS="date">2016-07-01</TD>
 <TD CLASS="size">86641</TD>
-<TD CLASS="sum">md5: 841c4c7607a5b853ea53b30171faf328<BR>sha1: 1d6656a0171f5697582870f7e02b5f9df4aa8e6c</TD>
-</TR>
-
-
-<TR>
-<TD CLASS="name"><A HREF="refman-5.0.pdf">refman-5.0.pdf</A></TD>
-<TD CLASS="date">2003-11-25</TD>
-<TD CLASS="size">474818</TD>
-<TD CLASS="sum">md5: b6eb330e98446f2040cb61ee557b24ea<BR>sha1: 21b4ee382b588f111b7789e46da1d5d797b945f3</TD>
+<TD CLASS="sum">7d73f55384a862f0f032feabfa8de96203ba03fcf4179491bad232d2ee0f3b3e</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-5.0.ps.gz">refman-5.0.ps.gz</A></TD>
 <TD CLASS="date">2003-11-25</TD>
 <TD CLASS="size">224198</TD>
-<TD CLASS="sum">md5: 4b0cedef4880bf925da9537520d93b57<BR>sha1: 9fa9faac3a5dc1c4479175a085d3f4ef48189260</TD>
+<TD CLASS="sum">d3a73f9435fec6582f88c2efdb0d2ede4d2824ff595cdcc766c44fb08684785d</TD>
 </TR>
 
 <TR>
-<TD CLASS="name"><A HREF="refman-4.0.pdf">refman-4.0.pdf</A></TD>
-<TD CLASS="date">2000-11-07</TD>
-<TD CLASS="size">446955</TD>
-<TD CLASS="sum">md5: fb36fbb993e70c6f71d359d95ed87129<BR>sha1: e6e7bef7794b49289d938af87385356b2511d926</TD>
+<TD CLASS="name"><A HREF="refman-5.0.pdf">refman-5.0.pdf</A></TD>
+<TD CLASS="date">2003-11-25</TD>
+<TD CLASS="size">474818</TD>
+<TD CLASS="sum">07cc73d3e9a818067eac1f3cf904ac26834c36f46bd2125d2325358c5a380ad5</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-4.0.ps.gz">refman-4.0.ps.gz</A></TD>
 <TD CLASS="date">2000-11-06</TD>
 <TD CLASS="size">156876</TD>
-<TD CLASS="sum">md5: 5454698095c45917ce80c934066cb76c<BR>sha1: 9191b371814f93fe5223c443ca44cb73b9c45cd4</TD>
+<TD CLASS="sum">81124c666d219c8f6c144012f992d74bef23e052fdd24b7c469250ef9d811e6c</TD>
 </TR>
 
 <TR>
-<TD CLASS="name"><A HREF="refman-3.2.pdf">refman-3.2.pdf</A></TD>
-<TD CLASS="date">1999-07-08</TD>
-<TD CLASS="size">321348</TD>
-<TD CLASS="sum">md5: fe012393b3bd11e069231a21f5ffdd20<BR>sha1: 9c9a86d2145c52fd705d3487c06c7d4eaf7bf2dd</TD>
+<TD CLASS="name"><A HREF="refman-4.0.pdf">refman-4.0.pdf</A></TD>
+<TD CLASS="date">2000-11-07</TD>
+<TD CLASS="size">446955</TD>
+<TD CLASS="sum">c4dfc6046ba09a64f0062f65d86016408f0fcf5d9ae6c16dc24c51e333b304ee</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-3.2.ps.gz">refman-3.2.ps.gz</A></TD>
 <TD CLASS="date">1999-07-02</TD>
 <TD CLASS="size">136552</TD>
-<TD CLASS="sum">md5: 5b5a0b716194fcbc374ed9aac3c078e3<BR>sha1: e438b5b53d2f05f28e5f1e1f0c62d4a6da0aaac0</TD>
+<TD CLASS="sum">401ecac840bdea0f3cf129a9b74eea349cd6258fb1edc2af1caf69d84b0cecfc</TD>
+</TR>
+
+<TR>
+<TD CLASS="name"><A HREF="refman-3.2.pdf">refman-3.2.pdf</A></TD>
+<TD CLASS="date">1999-07-08</TD>
+<TD CLASS="size">321348</TD>
+<TD CLASS="sum">454dc05959e8b9c7a72fcb261643df9abc2028f0e394eb7b7a6ab9c6561344e6</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-3.1.ps.gz">refman-3.1.ps.gz</A></TD>
 <TD CLASS="date">1998-07-01</TD>
 <TD CLASS="size">129519</TD>
-<TD CLASS="sum">md5: 852e53df287708c8335f3de37e5856a3<BR>sha1: 5a441993778e4dd6c0c5e34536c78fd40c3449b8</TD>
+<TD CLASS="sum">7d0d0fa10eeb18965a2f06e1bfbe223a74fa9d2b4b68ad8951750f00eaaa896a</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-2.5.ps.gz">refman-2.5.ps.gz</A></TD>
 <TD CLASS="date">1996-11-18</TD>
 <TD CLASS="size">115860</TD>
-<TD CLASS="sum">md5: bec74e774059051f88525078f2b1c347<BR>sha1: 3237be1d8e0e8a15f2b4d7e8d55b4d61378c1d09</TD>
+<TD CLASS="sum">7f4951eb2eb3c1eceabf7571275c7f856d0f89342aa40e59b46e6c3c656508c0</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-2.4.ps.gz">refman-2.4.ps.gz</A></TD>
 <TD CLASS="date">1996-05-14</TD>
 <TD CLASS="size">69189</TD>
-<TD CLASS="sum">md5: f4e7508b4c4685e7fa8e33a49f67b344<BR>sha1: ca609ac0f5fc7f70cd98f1309aa0c30cb210ad72</TD>
+<TD CLASS="sum">8ae641b31cc70ed838ab4449825d2003c82cac5d399a3fa8d81a357c75cc5bd8</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-2.2.ps.gz">refman-2.2.ps.gz</A></TD>
 <TD CLASS="date">1995-11-28</TD>
 <TD CLASS="size">56724</TD>
-<TD CLASS="sum">md5: b1f2a2c7cfdae338bfba9314f5c8cc12<BR>sha1: c20a72f4f1336e5d0811b0b8f75fad26a64c6e5c</TD>
+<TD CLASS="sum">9c76439231a444c96bacccc378b06f09465324f9d38ce406376c1d2c5a7723ca</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-2.1.ps.gz">refman-2.1.ps.gz</A></TD>
 <TD CLASS="date">1995-02-08</TD>
 <TD CLASS="size">55171</TD>
-<TD CLASS="sum">md5: 5d526b9b9fa4566feb18b3f0836abbc7<BR>sha1: 763402fa89946d3cf0f2707566c008cad7e58fbc</TD>
+<TD CLASS="sum">b3ef5e53b302083c7e14d721339abfbc8c0f74d1244771df2962f697a7a41eb1</TD>
 </TR>
 
 <TR>
 <TD CLASS="name"><A HREF="refman-1.1.ps.gz">refman-1.1.ps.gz</A></TD>
 <TD CLASS="date">1994-05-27</TD>
 <TD CLASS="size">45131</TD>
-<TD CLASS="sum">md5: eecb396a07098c93c82a271346d33cc3<BR>sha1: 58d1d980296138b8a33723b1749b633b551bb5c7</TD>
+<TD CLASS="sum">39c920fcefc7983c9c785509f90f0cbb6d1404f2543f0c925c5eb2459bec8144</TD>
 </TR>
 
 </TABLE>
 
 <P CLASS="footer">
 Last update:
-Tue Dec  8 10:29:13 UTC 2020
+Mon Jan 31 12:31:37 UTC 2022
 </P>
 <!--
-Last change: Lua 5.4.2 released
+Last change: use sha256 checksums
 -->
 
 </BODY>


### PR DESCRIPTION
The Lua downloads page now only advertises SHA256 sums. This fixes the regex.