### PR TITLE
Change the official Lua URL from www.lua.org to lua.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ $ lenv vers
 ...snip...
 ```
 
+**Package URL's**
+
+the following URL's are used to download the version files and source files.
+
+- Lua: https://lua.org/ftp/
+- LuaJIT: https://github.com/LuaJIT/LuaJIT.git
+- LuaRocks: https://luarocks.github.io/luarocks/releases/
+
 
 ## Usage
 

--- a/fetch.go
+++ b/fetch.go
@@ -153,6 +153,12 @@ func CmdFetch() {
 			}
 			defer rsp.Body.Close()
 
+			// check status code
+			if rsp.StatusCode != http.StatusOK {
+				eprintf("failed to download %q: %s\n", target.cfg.ReleaseURL, rsp.Status)
+				continue
+			}
+
 			b, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				eprintf("failed to read body: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ var (
 		Name:        "lua",
 		RootDir:     filepath.Join(LenvDir, "lua"),
 		VersionFile: filepath.Join(LenvDir, "lua_vers.txt"),
-		ReleaseURL:  "http://www.lua.org/ftp/",
-		DownloadURL: "http://www.lua.org/ftp/",
+		ReleaseURL:  "http://lua.org/ftp/",
+		DownloadURL: "http://lua.org/ftp/",
 	}
 	LuaJitCfg = &TargetConfig{
 		Name:        "luajit",


### PR DESCRIPTION
the file cannot be retrieved because the updated server certificate is not a wildcard certificate.