### PR TITLE
Add -p/--project option to install Lua/LuaRocks in current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Lua Version Manager.
 1. download a binary release from the [releases](https://github.com/mah0x211/lenv/releases) page.
 2. extract the downloaded file and place the `lenv` command in the desired location. (e.g. `/usr/local/bin/lenv`)
 3. run a `lenv setup` command to set up the required files and directories.
-    - you can also run a `lenv -g setup` command to set up the required files and directories in the `/usr/local/lenv` directory.
+    - run `lenv -g setup` command to set up in the global directory.
+    - run `lenv -p setup` command to set up in the project (current) directory.
 
 **Setting up the `.lenvrc` file.**
 
@@ -38,6 +39,32 @@ Usage:
 
 Options:
   -g, --global                   Use /usr/local/lenv as installation directory
+  -p, --project                  Use current directory as installation directory
+
+  Note:
+    The lenv command searches for a .lenv directory in the current directory,
+    then recursively in each parent directory up to the root. If found, that
+    becomes the install directory.
+    If it finds no .lenv directory, it uses /usr/local/lenv if it exists;
+    otherwise, it uses $HOME/.lenv (e.g., /home/foo/.lenv). The default
+	directory is used even if it doesn't exist yet.
+
+    For example, with this directory structure:
+
+      /
+      ├── home
+      │   └── foo
+      │       ├── .lenv
+      │       └── bar
+      │           └── baz
+      │               └── .lenv
+      └── qux
+
+    If you run lenv:
+    - in baz, it uses baz/.lenv.
+    - in bar, it uses foo/.lenv.
+    - in qux, it finds no .lenv directory, so it uses /usr/local/lenv if it
+	  exists; otherwise, $HOME/.lenv (i.e., /home/foo/.lenv).
 
 Commands:
   help                           Show this message

--- a/help.go
+++ b/help.go
@@ -24,6 +24,33 @@ Usage:
 
 Options:
   -g, --global                   Use /usr/local/lenv as installation directory
+  -p, --project                  Use current directory as installation directory
+
+  Note:
+    The lenv command searches for a .lenv directory in the current directory,
+    then recursively in each parent directory up to the root. If found, that
+    becomes the install directory.
+    If it finds no .lenv directory, it uses /usr/local/lenv if it exists;
+    otherwise, it uses $HOME/.lenv (e.g., /home/foo/.lenv). The default
+	directory is used even if it doesn't exist yet.
+
+    For example, with this directory structure:
+
+      /
+      ├── home
+      │   └── foo
+      │       ├── .lenv
+      │       └── bar
+      │           └── baz
+      │               └── .lenv
+      └── qux
+
+    If you run lenv:
+    - in baz, it uses baz/.lenv.
+    - in bar, it uses foo/.lenv.
+    - in qux, it finds no .lenv directory, so it uses /usr/local/lenv if it
+	  exists; otherwise, $HOME/.lenv (i.e., /home/foo/.lenv).
+
 
 Commands:
   help                           Show this message


### PR DESCRIPTION
This change introduces -p/--project flags that allow users to create project-specific Lua environments by installing to .lenv subdirectory in the current working directory. This provides better isolation for project-specific dependencies and configurations compared to using the global or user's home directory installations.