### PR TITLE
Fix module path resolution using luarocks path command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,30 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      # -
-      #   name: Install APT Packages
-      #   run: |
-      #     sudo apt update
-      #     sudo apt-get -V install -y make gcc
-      - name: Install Go
+      -
+        name: Install APT Packages (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install luarocks
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      -
+        name: Install Homebrew Packages (macOS only)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install luarocks
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+      -
+        name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Checkout code
+      -
+        name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Test
+      -
+        name: Test
         run: make test
-
-      - name: Codecov
+      -
+        name: Codecov
         uses: codecov/codecov-action@v3

--- a/path.go
+++ b/path.go
@@ -1,31 +1,131 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
 
-func get_luacpath() string {
-	return filepath.Clean(CurrentDir+"/lua_modules/luaclib") + "/?.so;;"
-}
-
-func get_luapath() string {
-	prefix := filepath.Clean(CurrentDir + "/lua_modules/lualib")
-	paths := []string{
-		prefix + "/?.lua",
-		prefix + "/?/init.lua",
+func GetLuaRocksPath() map[string][]map[string]string {
+	// get luarocks pathnames
+	var buf bytes.Buffer
+	if err := DoExecEx("luarocks", &buf, os.Stderr, "path"); err != nil {
+		fatalf("failed to get luarocks path: %v", err)
 	}
-	return strings.Join(paths, ";") + ";;"
+
+	pathnames := map[string][]map[string]string{}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		arr := strings.SplitN(line, "='", 2)
+		if len(arr) != 2 || !strings.HasPrefix(arr[0], "export ") {
+			continue
+		}
+		name := strings.TrimPrefix(arr[0], "export ")
+		paths := strings.TrimSuffix(arr[1], "'")
+
+		switch name {
+		case "PATH":
+			for _, v := range strings.Split(paths, ":") {
+				pathname := pathnames[name]
+				if pathname == nil {
+					pathname = []map[string]string{}
+					pathnames[name] = pathname
+				}
+				pathname = append(pathname, map[string]string{
+					"pathname": v,
+				})
+				// sort by pathname
+				// sort.Slice(pathname, func(i, j int) bool {
+				// 	return pathname[i]["pathname"] < pathname[j]["pathname"]
+				// })
+			}
+
+		case "LUA_PATH", "LUA_CPATH":
+			for _, v := range strings.Split(paths, ";") {
+				// extract object extension
+				kv := strings.SplitN(v, "/?", 2)
+				if len(kv) == 2 {
+					pathname := pathnames[name]
+					if pathname == nil {
+						pathname = []map[string]string{}
+					}
+					pathname = append(pathname, map[string]string{
+						"pathname": v,
+						"dirname":  kv[0],
+						"basename": "?" + kv[1],
+					})
+					// sort by pathname
+					// sort.Slice(pathname, func(i, j int) bool {
+					// 	return pathname[i]["pathname"] < pathname[j]["pathname"]
+					// })
+					pathnames[name] = pathname
+				}
+			}
+		}
+	}
+
+	return pathnames
 }
 
-func get_path() string {
+func getLuaCPath(rockspath map[string][]map[string]string) string {
+	if len(rockspath) == 0 {
+		// extract LUA_CPATH from luarocks
+		rockspath = GetLuaRocksPath()
+	}
+	cpath := rockspath["LUA_CPATH"]
+	if cpath == nil {
+		fatalf("failed to get LUA_CPATH from luarocks path command")
+	}
+
+	// get unique basenames
+	basenames := map[string]bool{}
+	for _, pathname := range cpath {
+		basenames[pathname["basename"]] = true
+	}
+
+	prefix := filepath.Join(CurrentDir, "lua_modules/luaclib")
+	pathnames := []string{}
+	for basename := range basenames {
+		pathnames = append(pathnames, fmt.Sprintf("%s/%s", prefix, basename))
+	}
+	return strings.Join(pathnames, ";") + ";;"
+}
+
+func getLuaPath(rockspath map[string][]map[string]string) string {
+	if len(rockspath) == 0 {
+		// extract LUA_PATH from luarocks
+		rockspath = GetLuaRocksPath()
+	}
+	luapath := rockspath["LUA_PATH"]
+	if luapath == nil {
+		fatalf("failed to get LUA_PATH")
+	}
+
+	// get unique basenames
+	basenames := map[string]bool{}
+	for _, pathname := range luapath {
+		basenames[pathname["basename"]] = true
+	}
+
+	prefix := filepath.Join(CurrentDir, "lua_modules/lualib")
+	pathnames := []string{}
+	for basename := range basenames {
+		pathnames = append(pathnames, fmt.Sprintf("%s/%s", prefix, basename))
+	}
+	return strings.Join(pathnames, ";") + ";;"
+}
+
+func getPath() string {
 	return strings.Join([]string{
-		filepath.Clean(CurrentDir + "/bin"),
-		filepath.Clean(CurrentDir + "/lua_modules/bin"),
+		filepath.Join(CurrentDir, "bin"),
+		filepath.Join(CurrentDir, "lua_modules/bin"),
 	}, ":")
 }
 
 func printAll() {
+	rockspath := GetLuaRocksPath()
+
 	printf(`
 #
 # please add the following lenv settings to your environment
@@ -36,13 +136,13 @@ func printAll() {
 		var value string
 		switch name {
 		case "PATH":
-			value = get_path() + ":$PATH"
+			value = getPath() + ":$PATH"
 
 		case "LUA_PATH":
-			value = get_luapath()
+			value = getLuaPath(rockspath)
 
 		case "LUA_CPATH":
-			value = get_luacpath()
+			value = getLuaCPath(rockspath)
 		}
 		printf(`export %s="%s"`, name, value)
 	}
@@ -53,15 +153,15 @@ func CmdPath(opts []string) {
 	if len(opts) > 0 {
 		switch opts[0] {
 		case "bin":
-			printf(get_path())
+			printf(getPath())
 			return
 
 		case "lualib":
-			printf(get_luapath())
+			printf(getLuaPath(nil))
 			return
 
 		case "luaclib":
-			printf(get_luacpath())
+			printf(getLuaCPath(nil))
 			return
 		}
 	}


### PR DESCRIPTION
Previously, path extensions for module lookup were hardcoded, which
could lead to incorrect paths in custom environments. This change:

- Extracts actual path patterns from luarocks path command output
- Collects unique basename patterns for each module type
- Constructs accurate module search paths dynamically

This fix prevents module loading failures by ensuring paths always
match the actual structure of installed Lua modules.