### PR TITLE
Fix bug when switching both Lua and LuaRocks versions

### DIFF
--- a/use.go
+++ b/use.go
@@ -41,6 +41,13 @@ func UseInstalledVersion(cfg *TargetConfig, ver string) {
 			}
 
 			printf("use %s version %s (%q)", cfg.Name, ver, src)
+
+			if err := os.Chdir(CWD); err != nil {
+				fatalf("failed to chdir to %q: %v", CWD, err)
+			} else if cfg.Name != "luarocks" {
+				// resolve current dir if it is not luarocks
+				ResolveCurrentDir()
+			}
 			return
 		}
 	}


### PR DESCRIPTION
The issue occurred when switching LuaRocks version after Lua version, resulting in "not installed" errors even when the version existed. This happened because the working directory changed during Lua version switching, causing incorrect path resolution for LuaRocks.